### PR TITLE
fix: Ignore activity when streams is empty

### DIFF
--- a/grava_init_backend.py
+++ b/grava_init_backend.py
@@ -351,7 +351,7 @@ def getAndStoreGpxData(activity, start_date):
     streams = strava.get_activity_streams(activity.id, types = types, resolution='medium')
     datapointcount = 0
 
-    if "time" not in streams.keys():
+    if not streams or "time" not in streams.keys():
         return False
 
     for datapoint in streams['time'].data:


### PR DESCRIPTION
If an activity is manually added (ie without any gps data), then streams is empty and you get 
```AttributeError: 'NoneType' object has no attribute 'keys'```